### PR TITLE
✨ Update Parquet writing to use v2 format with optimized sorting

### DIFF
--- a/datadex/owid.py
+++ b/datadex/owid.py
@@ -41,9 +41,17 @@ def owid_indicators(
 
 def write_parquet(df: pl.DataFrame, path: str) -> None:
     """
-    Write a DataFrame to a parquet file.
+    Write a DataFrame to a parquet file using Parquet version 2.0
+    and sorted by iso_code and year for optimal query performance.
     """
-    df.write_parquet(path)
+    df = df.sort(["iso_code", "year"])
+    df.write_parquet(
+        path, 
+        compression="snappy", 
+        use_pyarrow=True, 
+        pyarrow_options={"version": "2.0"},
+        statistics=True
+    )
 
 
 def main() -> None:

--- a/datadex/wdi.py
+++ b/datadex/wdi.py
@@ -46,7 +46,15 @@ def world_development_indicators() -> pl.DataFrame:
 
 def main() -> None:
     df = world_development_indicators()
-    df.write_parquet("data/world_development_indicators.parquet")
+    # Sort by country_code, year, and indicator_code for optimal query performance
+    df = df.sort(["country_code", "year", "indicator_code"])
+    df.write_parquet(
+        "data/world_development_indicators.parquet",
+        compression="snappy",
+        use_pyarrow=True,
+        pyarrow_options={"version": "2.0"},
+        statistics=True
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements changes to use Parquet v2 format with optimized sorting for better performance.

- Set Parquet version to 2.0 using PyArrow options
- Add sorting to optimize query performance:
  - WDI data: Sort by country_code, year, and indicator_code
  - OWID data: Sort by iso_code and year
- Enable statistics for better query planning
- Use snappy compression for best performance/size trade-off

Fixes #78

Generated with [Claude Code](https://claude.ai/code)